### PR TITLE
[feat] Test Script 2_PartialLBAWrite Init version

### DIFF
--- a/CRA_Project_Tester/CRA_Project_Tester.vcxproj
+++ b/CRA_Project_Tester/CRA_Project_Tester.vcxproj
@@ -129,6 +129,7 @@
   <ItemGroup>
     <ClCompile Include="main.cpp" />
     <ClCompile Include="featureTEST.cpp" />
+    <ClCompile Include="test_ara.cpp">
     <ClCompile Include="test_suyong.cpp" />
     <ClCompile Include="tester.cpp" />
     <ClCompile Include="test_run.cpp" />

--- a/CRA_Project_Tester/CRA_Project_Tester.vcxproj.filters
+++ b/CRA_Project_Tester/CRA_Project_Tester.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="test_suyong.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="test_ara.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="tester.h">

--- a/CRA_Project_Tester/test_ara.cpp
+++ b/CRA_Project_Tester/test_ara.cpp
@@ -1,0 +1,32 @@
+#include "gmock/gmock.h"
+#include "tester.h"
+#include <string>
+
+using namespace testing;
+
+class MockRead : public Read {
+public:
+	MOCK_METHOD(void, run, (string, string), (override));
+	MOCK_METHOD(string, read, (string), ());
+};
+
+class MockWrite : public Write {
+public:
+	MOCK_METHOD(void, run, (string, string), (override));
+};
+
+
+TEST(SDDTEST, Test3)
+{
+	MockWrite mkwr;
+	MockRead mkrd;
+	SSDTest_PartialLBAWrite ssdtest3(&mkwr, &mkrd);
+
+	EXPECT_CALL(mkwr, run("4", "0x12345678"));
+	EXPECT_CALL(mkwr, run("0", "0x12345678"));
+	EXPECT_CALL(mkwr, run("3", "0x12345678"));
+	EXPECT_CALL(mkwr, run("2", "0x12345678"));
+	EXPECT_CALL(mkwr, run("1", "0x12345678"));
+
+	ssdtest3.run("","");
+}

--- a/CRA_Project_Tester/tester.cpp
+++ b/CRA_Project_Tester/tester.cpp
@@ -8,7 +8,7 @@ void SSDTest::FullWriteAndReadCompare()
 {
 }
 
-void SSDTest::PartialLBAWrite()
+void SSDTest_PartialLBAWrite::run(string param1, string param2)
 {
 }
 

--- a/CRA_Project_Tester/tester.h
+++ b/CRA_Project_Tester/tester.h
@@ -59,7 +59,17 @@ public:
 	void run(string command1 = "", string command2 = "") override;
 private:
 	void FullWriteAndReadCompare();
-	void PartialLBAWrite();
 	void WriteReadAging();
 };
 
+class SSDTest_PartialLBAWrite :public ITestOperation, public exception
+{
+public:
+	SSDTest_PartialLBAWrite(Write* w, Read* r) : mWrite(w), mRead(r) {};
+	SSDTest_PartialLBAWrite() : mWrite(nullptr), mRead(nullptr) {};
+	void run(string param1, string param2) override;
+
+private:
+	Write* mWrite;
+	Read* mRead;
+};


### PR DESCRIPTION
1. 금일 오전 미팅에서 확정된 인터페이스 구조에 따라 Test Script 2_PartialLBAWrite의 class 선언 as is: one test class with one dispatch function and multiple private function per each test script to be: test class per test script

2. mock test 초기버전 Test Script 2_PartialLBAWrite가 구현되어 있지 않아 테스트결과는 fail임. TTD::Red상태임.